### PR TITLE
Fix name badge and dotted line

### DIFF
--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -157,7 +157,20 @@ export const Editor = React.forwardRef(
         },
         ".cm-activeLine" : {
           "background-color" : "rgba(0, 0, 0, 1) !important",
-        }
+        },
+        "& .cm-scroller" : {
+          "minHeight" : "100vh"
+        },
+        ".cm-ySelectionInfo" : {
+          opacity: "1",
+          fontFamily: fontFamily,
+          color: "black",
+          padding: "3px 4px",
+          fontSize: "0.8rem",
+          "font-weight": "bold",
+          top: "1.25em",
+          "z-index": "1000"
+        },
       }),
       flokSetup(document, { readOnly }),
       languageExtension(),


### PR DESCRIPTION
This commit fixes:

> 1. I don't see the names anymore? Maybe something broke there?

> 6. I also see this .......... dotted line below the editor where i am currently typing in.

I also added `fontFamily` to the name badge, so the badge also changes with the selected font.